### PR TITLE
Adding DMARC Lookup functionality

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Charles Barnes
+DMARC functionality Copyright (c) 2020 Erik Lentz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.php
+++ b/index.php
@@ -53,6 +53,7 @@ header("Pragma: no-cache");
                             <option value="aaaa">IPV6/Get AAAA Record</option>
                             <option value="mx">Mx/Get MX Record</option>
                             <option value="txt">SPF/TXT</option>
+							<option value="Dmarc">DMARC</option>
                             <option value="blacklist">Blacklist Check</option>
                             <option value="whois">Whois</option>
                             <option value="port">Check If Port Open/Forwarded</option>
@@ -99,6 +100,10 @@ header("Pragma: no-cache");
                         <tr>
                             <td>SPF/TXT</td>
                             <td>A SPF Record is used to indicate which email hosts is authorized to send mail on the specified domain's behalf.  This query is used to get the authorized domains</td>
+                        </tr>
+						                        <tr>
+                            <td>DMARC</td>
+                            <td>A DMARC Record is used to authenticate email From: addresses and defines policies on where to report both authorized and unauthorized mailflow</td>
                         </tr>
                         <tr>
                             <td>Blacklist Check</td>

--- a/index.php
+++ b/index.php
@@ -53,7 +53,7 @@ header("Pragma: no-cache");
                             <option value="aaaa">IPV6/Get AAAA Record</option>
                             <option value="mx">Mx/Get MX Record</option>
                             <option value="txt">SPF/TXT</option>
-							<option value="Dmarc">DMARC</option>
+                            <option value="dmarc">DMARC</option>
                             <option value="blacklist">Blacklist Check</option>
                             <option value="whois">Whois</option>
                             <option value="port">Check If Port Open/Forwarded</option>

--- a/index.php
+++ b/index.php
@@ -101,7 +101,7 @@ header("Pragma: no-cache");
                             <td>SPF/TXT</td>
                             <td>A SPF Record is used to indicate which email hosts is authorized to send mail on the specified domain's behalf.  This query is used to get the authorized domains</td>
                         </tr>
-						                        <tr>
+                        <tr>
                             <td>DMARC</td>
                             <td>A DMARC Record is used to authenticate email From: addresses and defines policies on where to report both authorized and unauthorized mailflow</td>
                         </tr>

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -21,9 +21,9 @@ window.onload = function() {
             case "mx":
                 return "MX Lookup";
                 break;
-			case "Dmarc":
-				return "DMARC";
-				break;
+            case "dmarc":
+                return "DMARC";
+                break;
             case "a":
                 return "IP Lookup";
                 break;

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -21,6 +21,9 @@ window.onload = function() {
             case "mx":
                 return "MX Lookup";
                 break;
+			case "Dmarc":
+				return "DMARC";
+				break;
             case "a":
                 return "IP Lookup";
                 break;

--- a/operations/Dmarc.php
+++ b/operations/Dmarc.php
@@ -1,0 +1,10 @@
+<?php
+include_once('./OperationInterface.php');
+
+class Txt implements OperationInterface{
+    public function getOutput(_dmarc.$hostname){
+        $response = dns_get_record (_dmarc.$hostname , DNS_TXT);  
+        return json_encode($response, JSON_PRETTY_PRINT);     
+    }
+}
+?>

--- a/operations/Dmarc.php
+++ b/operations/Dmarc.php
@@ -1,9 +1,10 @@
 <?php
 include_once('./OperationInterface.php');
-
-class Txt implements OperationInterface{
-    public function getOutput(_dmarc.$hostname){
-        $response = dns_get_record (_dmarc.$hostname , DNS_TXT);  
+$dmarc = "_dmarc.";
+$dmarchostname = $dmarc . $hostname;
+class Dmarc implements OperationInterface{
+    public function getOutput($hostname){
+        $response = dns_get_record ($hostname , DNS_TXT);  
         return json_encode($response, JSON_PRETTY_PRINT);     
     }
 }

--- a/operations/index.php
+++ b/operations/index.php
@@ -45,6 +45,10 @@ if(isset($domain) && $domain !=null){
       include_once('./Txt.php');
       $object = new Txt;
       break;
+    case 'dmarc':
+      include_once('./Dmarc.php');
+      $object = new Dmarc;
+      break;
     case 'whois':
       include_once('./Whois.php');
       $object = new WhoisOutput;


### PR DESCRIPTION
Hi there!
 I love this tool. While the TXT functionality can be used to perform DMARC lookups by the end user manually concatenating _dmarc. to the front of the hostname, I thought it might be easier and more user friendly to perform this work for the user and add it in as a separate function.

This is my very first pull request and I have almost no idea what I'm doing, so apologies if I've made a mistake.

Thanks,
Erik