### PR TITLE
Prevent 301 redirects

### DIFF
--- a/javascript/main.js
+++ b/javascript/main.js
@@ -72,7 +72,7 @@ window.onload = function() {
                 }
             }
             document.getElementById("loading").innerHTML = '<div class="sk-three-bounce"><div class="sk-child sk-bounce1"></div><div class="sk-child sk-bounce2"></div><div class="sk-child sk-bounce3"></div></div>'
-            xmlhttp.open("GET", "operations?domain=" + domain + "&request=" + callType + "&port=" + port, true);
+            xmlhttp.open("GET", "operations/?domain=" + domain + "&request=" + callType + "&port=" + port, true);
             xmlhttp.send();
             
         }


### PR DESCRIPTION
`operations` is a directory, not a resource.
Apache throws a 301 redirect when the `/` is missing from the URL and this breaks some proxy configurations, and the 301 is simply not needed.